### PR TITLE
Enable dependabot for updating github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+---
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+    groups:
+      gh-actions-minor:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: hmarr/debug-action@v2
 
   check-mergeability:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.actor == 'nsmbot' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && (github.actor == 'nsmbot' || github.actor == 'dependabot') }}
     uses: networkservicemesh/.github/.github/workflows/check-mergeability.yaml@main
     secrets:
       token: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
This PR enables Dependabot in the repository to automatically check GitHub Actions versions weekly and create pull requests for any outdated dependencies found.